### PR TITLE
Release 1.0.5: Notification permission state logging and more

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "pushed-web-sdk",
-  "version": "1.0.4",
+  "name": "@pushedlab/pushed-web-sdk",
+  "version": "1.0.5",
   "description": "sdk for web pushes from pushed",
   "main": "src/lib/pushed.js",
   "types": "src/lib/pushed.d.ts",
@@ -24,5 +24,8 @@
   "dependencies": {
     "promise-polyfill": "^8.3.0",
     "whatwg-fetch": "^3.6.20"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -2,33 +2,39 @@ const config = {
     version: 1,
     platform: 'web',
     api: {
-        endpoint: 'https://api.pushed.ru',
-        registerEndpoint: '/v2/web-push/register',
-        authEndpoint: '/v2/web-push/auth-client'
+      endpoint: 'https://api.pushed.ru',
+      registerEndpoint: '/v2/web-push/register',
+      authEndpoint: '/v2/web-push/auth-client',
+      clientInteractionEndpoint: '/v2/web-push/confirm-client-interaction',
+      generateTokenEndpoint: '/v2/web-push/generate-client-token',
+      setNotificationPermissionStateEndpoint: '/v2/web-push/set-notification-permission-state'
     },
     vapidDetails: {
-        publicKey: 'BKkzxPkCIPpSGAzVx3g3AHOsA738n64rNa7T9ERP1I8fSgLQGxZLjNYw9ABNTf0Mbdp8_4MXufXa8q3t_7epHCI'
+      publicKey: 'BKkzxPkCIPpSGAzVx3g3AHOsA738n64rNa7T9ERP1I8fSgLQGxZLjNYw9ABNTf0Mbdp8_4MXufXa8q3t_7epHCI'
     },
     localStorageKeys: {
-        token: 'clientToken',
-        tokenTimestamp: 'tokenTimestamp',
-        apiEndpoint: 'pushedApiEndpoint',
-        proxyApiEndpoint: 'proxyApiEndpoint',
-        environment: 'pushedEnvironment',
+      token: 'clientToken',
+      tokenTimestamp: 'tokenTimestamp',
+      apiEndpoint: 'pushedApiEndpoint',
+      proxyApiEndpoint: 'proxyApiEndpoint',
+      environment: 'pushedEnvironment',
     },
     serviceWorker: {
-        fileName: 'sw.js'
+      fileName: 'sw.js'
+    },
+    token: {
+      lifetime: 24 * 60 * 60 // 24 hours
     },
     logic: {
-        deviceValidationDelay: 5000
+      deviceValidationDelay: 5000
     }
-};
-
-export default config;
-
-try {
+  };
+  
+  export default config;
+  
+  try {
     module.exports = config;
-}
-catch (err) {
+  }
+  catch (err) {
     //ignore
-}
+  }

--- a/src/lib/pushed.d.ts
+++ b/src/lib/pushed.d.ts
@@ -4,4 +4,5 @@ declare module 'pushed-web-sdk' {
     export function validateSubscription(): Promise<string>;
     export function setApiEndpoint(): void;
     export function requestNotificationPermission(): Promise<boolean>;
+    export function unsubscribeAndRemoveToken(): Promise<void>;
 }

--- a/src/lib/pushed.js
+++ b/src/lib/pushed.js
@@ -3,211 +3,252 @@ import config from '../config';
 import Base64 from '../util/base64';
 
 var Pushed = {
-    async requestNotificationPermission() {
-        if (Notification.permission === 'default') {
-            const permission = await Notification.requestPermission();
-            return permission === 'granted';
-        }
-        return Notification.permission === 'granted';
-    },
-
-    async registerWebPushes() {
-        this.isSupportWebPush();
-
-        const isPermissionGranted = await this.requestNotificationPermission();
-
-        if (!isPermissionGranted) {
-            throw new Error('Request permissions was denied');
-        }
-
-        const registration = await this.getRegistration();
-        const subscription = await registration.pushManager.getSubscription();
-
-        if (!subscription) {
-            return await this.register();
-        }
-
-        return await this.validateSubscription();
-    },
-
-    async validateSubscription() {
-        this.isSupportWebPush();
-
-        const permission = Notification.permission;
-        if (permission !== 'granted') {
-            throw new Error('Request permissions was denied or not requested');
-        }
-
-        const registration = await this.getRegistration();
-        const subscription = await registration.pushManager.getSubscription();
-        const clientToken = localStorage.getItem(config.localStorageKeys.token);
-
-        if (!clientToken) {
-            if (subscription){
-                await subscription.unsubscribe();
-            }
-
-            return await this.register();
-        }
-
-        const tokenTimestamp = this.getSavedTokenTimestamp();
-        const currentTime = this.getCurrentUnixTime();
-        const tokenLifetime = 24 * 60 * 60; //24 hours
-
-        if (tokenTimestamp && currentTime - tokenTimestamp < tokenLifetime) {
-            return clientToken;
-        }
-
-        if (subscription){
-            await subscription.unsubscribe();
-        }
-
-        return await this.register();
-    },
-
-    async register() {
-        const registration = await this.getRegistration();
-        const subscription = await registration.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: Base64.urlB64ToUint8Array(config.vapidDetails.publicKey) });
-
-        const token = localStorage.getItem(config.localStorageKeys.token);
-        const jsonSubscription = JSON.parse(JSON.stringify(subscription));
-
-        const auth = jsonSubscription.keys.auth;
-        const p256dhKey = jsonSubscription.keys.p256dh;
-        const webApiEndpoint = jsonSubscription.endpoint;
-
-        if (!p256dhKey || !auth || !webApiEndpoint) {
-            throw new Error('The push subscription is missing a required field.');
-        }
-
-        const postData = {
-            sdkVersion: config.version,
-            auth: auth,
-            webApiEndpoint: webApiEndpoint,
-            P256dhKey: p256dhKey,
-            hostname: self.location.hostname,
-            clientToken: token
-        };
-
-        let response;
-        let responseClientToken = '';
-
-        try {
-            response = await api.post(config.api.registerEndpoint, postData);
-        }
-        catch (e) {
-            throw new Error(`The API request failed: ${e.message}`, e);
-        }
-
-        if (!response.success || !response.model.clientToken) {
-            throw new Error('An unexpected response was received from the Pushed API.');
-        }
-
-        responseClientToken = response.model.clientToken;
-        localStorage.setItem(config.localStorageKeys.token, responseClientToken);
-
-        const unixDateTime = this.getCurrentUnixTime();
-        localStorage.setItem(config.localStorageKeys.tokenTimestamp, unixDateTime);
-
-        return responseClientToken;
-    },
-
-    async setNotificationListener(handler) {
-        if (!('PushManager' in self) || !('serviceWorker' in navigator || typeof ServiceWorkerRegistration !== 'undefined')) {
-            return console.error('Web push is not supported by this browser.');
-        }
-
-        if (navigator.serviceWorker) {
-            await navigator.serviceWorker.ready;
-        }
-
-        if (!navigator.serviceWorker) {
-            throw new Error('Service Worker not found');
-        }
-
-        navigator.serviceWorker.addEventListener('message', function (event) {
-            if (!event.data && event.detail) {
-                event.data = event.detail;
-            }
-
-            if (event.data && event.data._pushed) {
-                handler(event.data);
-            }
-        });
-    },
-
-    setApiEndpoint(endpoint) {
-        if (!endpoint || typeof endpoint !== 'string') {
-            return;
-        }
-
-        const localStorage = self.localStorage;
-
-        if (!localStorage) {
-            throw new Error('Local storage is not supported by this browser.');
-        }
-
-        const previousEndpoint = localStorage.getItem(config.localStorageKeys.apiEndpoint);
-
-        if (endpoint != previousEndpoint) {
-            localStorage.removeItem(config.localStorageKeys.token);
-            localStorage.setItem(config.localStorageKeys.apiEndpoint, endpoint);
-        }
-    },
-
-    getSavedTokenTimestamp() {
-        const tokenTimestamp = localStorage.getItem(config.localStorageKeys.tokenTimestamp);
-        return tokenTimestamp ? parseInt(tokenTimestamp, 10) : null;
-    },
-
-    getCurrentUnixTime() {
-        return Math.floor(Date.now() / 1000);
-    },
-
-    async getRegistration() {
-        let registration;
-
-        try {
-            if (navigator.serviceWorker) {
-                registration = await navigator.serviceWorker.register(`/${config.serviceWorker.fileName}`);
-            } else if (self.registration) {
-                registration = self.registration;
-            }
-        }
-        catch (e) {
-            throw Error(`Failed to load '${self.location.origin}/${config.serviceWorker.fileName}': ${e.message}`, e);
-        }
-
-        if (navigator.serviceWorker) {
-            await navigator.serviceWorker.ready;
-        }
-
-        return registration;
-    },
-
-    isSupportWebPush() {
-        if (!('PushManager' in self) || !('serviceWorker' in navigator || typeof ServiceWorkerRegistration !== 'undefined')) {
-            if (/iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) {
-                throw new Error('For Web Push on iOS 16.4+, you will first need to click the "Share" button -> "Add to Home Screen" before you can sign up for push notifications.');
-            }
-            else {
-                throw new Error('Web push is not supported');
-            }
-        }
-
-        const localStorage = self.localStorage;
-
-        if (!localStorage) {
-            throw new Error('Local storage is not supported');
-        }
+  async requestNotificationPermission() {
+    if (Notification.permission === 'default') {
+      const permission = await Notification.requestPermission();
+      return permission === 'granted';
     }
+    return Notification.permission === 'granted';
+  },
+
+  async registerWebPushes() {
+    this.isSupportWebPush();
+    const token = await this.getTokenIfNotExist();
+
+    const isPermissionGranted = await this.requestNotificationPermission();
+
+    if (!isPermissionGranted) {
+      this.setNotificationPermissionState('Denied', token);
+      throw new Error('Request permissions was denied');
+    }
+
+    this.setNotificationPermissionState('Granted', token);
+    const registration = await this.getRegistration();
+    const subscription = await registration.pushManager.getSubscription();
+
+    if (!subscription) {
+      return await this.register();
+    }
+
+    return await this.validateSubscription();
+  },
+
+  async validateSubscription() {
+    this.isSupportWebPush();
+    const token = await this.getTokenIfNotExist();
+
+    const permission = Notification.permission;
+    if (permission !== 'granted') {
+      this.setNotificationPermissionState('Denied', token);
+      throw new Error('Request permissions was denied or not requested');
+    }
+
+    this.setNotificationPermissionState('Granted', token);
+    const registration = await this.getRegistration();
+    const subscription = await registration.pushManager.getSubscription();
+    const clientToken = localStorage.getItem(config.localStorageKeys.token);
+
+    const tokenTimestamp = this.getSavedTokenTimestamp();
+    const currentTime = this.getCurrentUnixTime();
+
+    if (tokenTimestamp && currentTime - tokenTimestamp < config.token.lifetime) {
+      return clientToken;
+    }
+
+    if (subscription){
+      return await subscription.unsubscribe();
+    }
+
+    return await this.register();
+  },
+
+  async register() {
+    const registration = await this.getRegistration();
+    const subscription = await registration.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: Base64.urlB64ToUint8Array(config.vapidDetails.publicKey) });
+
+    const token = localStorage.getItem(config.localStorageKeys.token);
+    const jsonSubscription = JSON.parse(JSON.stringify(subscription));
+
+    const auth = jsonSubscription.keys.auth;
+    const p256dhKey = jsonSubscription.keys.p256dh;
+    const webApiEndpoint = jsonSubscription.endpoint;
+
+    if (!p256dhKey || !auth || !webApiEndpoint) {
+      throw new Error('The push subscription is missing a required field.');
+    }
+
+    const postData = {
+      sdkVersion: config.version,
+      auth: auth,
+      webApiEndpoint: webApiEndpoint,
+      P256dhKey: p256dhKey,
+      hostname: self.location.hostname,
+      clientToken: token
+    };
+
+    let response;
+    let responseClientToken = '';
+
+    try {
+      response = await api.post(config.api.registerEndpoint, postData);
+    }
+    catch (e) {
+      throw new Error(`The API request failed: ${e.message}`, e);
+    }
+
+    if (!response.success || !response.model.clientToken) {
+      throw new Error('An unexpected response was received from the Pushed API.');
+    }
+
+    responseClientToken = response.model.clientToken;
+    localStorage.setItem(config.localStorageKeys.token, responseClientToken);
+
+    const unixDateTime = this.getCurrentUnixTime();
+    localStorage.setItem(config.localStorageKeys.tokenTimestamp, unixDateTime);
+
+    return responseClientToken;
+  },
+
+  async getTokenIfNotExist() {
+    const token = localStorage.getItem(config.localStorageKeys.token);
+
+    if (!token) {
+      const newToken = await api.post(config.api.generateTokenEndpoint, {});
+      const tokenValue = newToken.model.clientToken;
+      localStorage.setItem(config.localStorageKeys.token, tokenValue);
+
+      const unixDateTime = this.getCurrentUnixTime();
+      localStorage.setItem(config.localStorageKeys.tokenTimestamp, unixDateTime.toString());
+      await this.register();
+      return tokenValue;
+    }
+    return token;
+  },
+
+  async setNotificationListener(handler) {
+    if (!('PushManager' in self) || !('serviceWorker' in navigator || typeof ServiceWorkerRegistration !== 'undefined')) {
+      return console.error('Web push is not supported by this browser.');
+    }
+
+    if (navigator.serviceWorker) {
+      await navigator.serviceWorker.ready;
+    }
+
+    if (!navigator.serviceWorker) {
+      throw new Error('Service Worker not found');
+    }
+
+    navigator.serviceWorker.addEventListener('message', function (event) {
+      if (!event.data && event.detail) {
+        event.data = event.detail;
+      }
+
+      if (event.data && event.data._pushed) {
+        handler(event.data);
+      }
+    });
+  },
+
+  setNotificationPermissionState(state, clientToken) {
+    if (state !== 'Granted' && state !== 'Denied') {
+      throw Error('Wrong notification permission state');
+    }
+    if (!clientToken) {
+      throw Error('Client token is null or empty');
+    }
+    const data = {
+      ClientToken: clientToken,
+      NotificationPermissionState: state
+    };
+    api.post(config.api.setNotificationPermissionStateEndpoint, data);
+  },
+
+  setApiEndpoint(endpoint) {
+    if (!endpoint || typeof endpoint !== 'string') {
+      return;
+    }
+
+    const localStorage = self.localStorage;
+
+    if (!localStorage) {
+      throw new Error('Local storage is not supported by this browser.');
+    }
+
+    const previousEndpoint = localStorage.getItem(config.localStorageKeys.apiEndpoint);
+
+    if (endpoint != previousEndpoint) {
+      localStorage.removeItem(config.localStorageKeys.token);
+      localStorage.setItem(config.localStorageKeys.apiEndpoint, endpoint);
+    }
+  },
+
+  getSavedTokenTimestamp() {
+    const tokenTimestamp = localStorage.getItem(config.localStorageKeys.tokenTimestamp);
+    return tokenTimestamp ? parseInt(tokenTimestamp, 10) : null;
+  },
+
+  getCurrentUnixTime() {
+    return Math.floor(Date.now() / 1000);
+  },
+
+  async getRegistration() {
+    let registration;
+
+    try {
+      if (navigator.serviceWorker) {
+        registration = await navigator.serviceWorker.register(`/${config.serviceWorker.fileName}`);
+      } else if (self.registration) {
+        registration = self.registration;
+      }
+    }
+    catch (e) {
+      throw Error(`Failed to load '${self.location.origin}/${config.serviceWorker.fileName}': ${e.message}`, e);
+    }
+
+    if (navigator.serviceWorker) {
+      await navigator.serviceWorker.ready;
+    }
+
+    return registration;
+  },
+
+  async unsubscribeAndRemoveToken() {
+    const registration = self.registration;
+    if (!registration) {
+      return;
+    }
+    const subscription = await registration.pushManager.getSubscription();
+    if (subscription) {
+      await subscription.unsubscribe();
+    }
+
+    localStorage.removeItem(config.localStorageKeys.token);
+    localStorage.removeItem(config.localStorageKeys.tokenTimestamp);
+  },
+
+  isSupportWebPush() {
+    if (!('PushManager' in self) || !('serviceWorker' in navigator || typeof ServiceWorkerRegistration !== 'undefined')) {
+      if (/iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) {
+        throw new Error('For Web Push on iOS 16.4+, you will first need to click the "Share" button -> "Add to Home Screen" before you can sign up for push notifications.');
+      }
+      else {
+        throw new Error('Web push is not supported');
+      }
+    }
+
+    const localStorage = self.localStorage;
+
+    if (!localStorage) {
+      throw new Error('Local storage is not supported');
+    }
+  }
 }
 
 export default Pushed;
 
 try {
-    module.exports = Pushed;
+  module.exports = Pushed;
 }
 catch (err) {
-    //ignore
+  //ignore
 }

--- a/src/lib/sw.js
+++ b/src/lib/sw.js
@@ -1,49 +1,74 @@
+let requestPayload = null;
+
 self.addEventListener('push', function (event) {
-    var data = event.data.json() || {};
+  const data = event.data.json() || {};
+  const image = data.Image || 'https://multipushed.ru/favicon-32x32.png';
+  const title = data.Title || '';
+  const body = data.Body || '';
+  const actions = data.Actions || [];
 
-    var image = data.Image || 'https://pushed.ru/facicon-256x256.png';
+  requestPayload = getRequestPayload(data.WebClientToken, data.MessageId);
 
-    var title = data.Title || '';
-    var body = data.Body || '';
-
-    var options = {
-        body: body,
-        icon: image,
-        badge: image,
-        data: {
-            url: data.Url
-        }
-    };
-
-    if (data['_pushedCollapseKey'])
-        options.tag = data['_pushedCollapseKey'];
-
-    event.waitUntil(self.registration.showNotification(title, options));
-
-    clients.matchAll({ includeUncontrolled: true, type: 'window' }).then(clients => {
-        data._pushed = true;
-
-        clients.forEach(client => {
-            client.postMessage(data, [new MessageChannel().port2]);
-        });
-    });
-
-    serviceWorker.dispatchEvent(new CustomEvent('message', {detail: data}));
-    
-    if (data.WebClientToken && data.MessageId && data.ConfirmApiUrl){
-        let headers = new Headers();
-        const base64BasicHeader = self.btoa(data.WebClientToken + ":" + data.MessageId);
-
-        headers.set('Authorization', 'Basic ' + base64BasicHeader);
-
-        fetch(data.ConfirmApiUrl + "/v2/web-push/confirm", { method: 'POST', headers: headers });
+  const options = {
+    actions: actions,
+    body: body,
+    icon: image,
+    image: 'https://multipushed.ru/favicon-32x32.png',
+    badge: image,
+    data: {
+      url: data.Url
     }
+  };
+
+  event.waitUntil(
+      (async () => {
+        await self.registration.showNotification(title, options);
+        requestPayload && setClientInteractionStatus('Show', requestPayload);
+      })()
+  );
+
+  clients.matchAll({ includeUncontrolled: true, type: 'window' }).then(clients => {
+    data._pushed = true;
+
+    clients.forEach(client => {
+      client.postMessage(data, [new MessageChannel().port2]);
+    });
+  });
+
+  serviceWorker.dispatchEvent(new CustomEvent('message', {detail: data}));
 });
 
 self.addEventListener('notificationclick', function (event) {
-    event.notification.close();
-    var url = event.notification.data.url;
-    if (url) {
-        event.waitUntil(clients.openWindow(url));
-    }
+  requestPayload && setClientInteractionStatus('Click', requestPayload);
+  const url = event.notification.data.url;
+  if (url) {
+    event.waitUntil(clients.openWindow(url));
+  }
 });
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  return self.clients.claim();
+});
+
+function getRequestPayload(token, messageId) {
+  if (!token || !messageId) {
+    return null;
+  }
+
+  const headers = new Headers();
+  const base64BasicHeader = self.btoa(token + ':' + messageId);
+  headers.set('Authorization', 'Basic ' + base64BasicHeader);
+
+  return { method: 'POST', headers: headers };
+}
+
+function setClientInteractionStatus(status, requestPayload) {
+  if (status !== 'Show' && status !== 'Click' && status !== 'Close') {
+    throw Error('Wrong client interaction status');
+  }
+  fetch(`https://api.pushed.ru/v2/web-push/confirm-client-interaction?clientInteraction=${status}`, requestPayload);
+}


### PR DESCRIPTION
- ``` unsubscribeAndRemoveToken() ``` added - resets client token and SW subscription in one-time action
- Notification permission state is tracked now (Analytics)
- Client interaction state (Show / Click) is tracked now (Analytics)
- Client token can be generated without params
- Client token will be registered immediately when generated